### PR TITLE
Allow similarity table top left corner to cover left column too

### DIFF
--- a/out/style.css
+++ b/out/style.css
@@ -51,9 +51,11 @@ td[data-bucket="-0.0"] {
     background-color: hsl(0, 100%, 70%);
 }
 
-tr.header-row {
+tr.header-row,
+thead tr {
     position: sticky;
     top: 0;
+    z-index: 3;
     background: var(--background-color);
 }
 


### PR DESCRIPTION
At least, I think so. Haven't had a chance to run locally yet